### PR TITLE
Add theme scripts loading

### DIFF
--- a/applications/default/public/index.html
+++ b/applications/default/public/index.html
@@ -8,7 +8,7 @@
   <!-- Le styles -->
   <link ng-repeat="style in styles.styles" rel="stylesheet" ng-href="{{style}}">
   <link ng-repeat="style in theme.styles" rel="stylesheet" ng-href="{{style}}">
-  <link rel="stylesheet" href="lib/summernote/dist/summernote.css">
+  <link rel="stylesheet" href="lib/summernote/summernote-dist/summernote.css">
 
   <link rel="stylesheet" href="css/app.css">
 
@@ -35,7 +35,7 @@
 
   <script src="lib/jquery/jquery.min.js"></script>
   <script src="lib/bootstrap/dist/js/bootstrap.min.js"></script>
-  <script src="lib/summernote/dist/summernote.min.js"></script>
+  <script src="lib/summernote/summernote-dist/summernote.min.js"></script>
 
   <script src="lib/angular/angular.min.js"></script>
   <script src="lib/angular-route/angular-route.min.js"></script>


### PR DESCRIPTION
It seams to me that the feature for a theme to define JavaScript the way it can define CSS - in the theme settings file - is missing.

I'm not sure if this was on purpose, as in an Angular approaches you should consider having all of your JavaScript code attached to angular directives, and for that probably reside on choko extension directories, not themes, but it seems to make no harm to let the theme define JavaScript anyway.
