### PR TITLE
Allow routes to choose the method they use and specify a middleware.

### DIFF
--- a/applications/default/extensions/route/lib/route-controller.js
+++ b/applications/default/extensions/route/lib/route-controller.js
@@ -24,13 +24,22 @@ var RouteController = module.exports = function(application, settings) {
   var self = this;
   var app = this.application.application;
   var method = settings.method || 'all';
-  var middleware = settings.middleware || function (request, response, next) {
-    next();
-  };
 
-  app[method](self.settings.path, middleware, function(request, response) {
+  // Prepare route register params.
+  var params = [self.settings.path];
+
+  // Prepare the middleware, if available.
+  if ('middleware' in settings) {
+    params.push(settings.middleware);
+  }
+
+  // Prepare the route handler.
+  params.push(function(request, response) {
     self.handle(request, response);
   });
+
+  // Register on express.
+  app[method].apply(app, params);
 };
 
 /**


### PR DESCRIPTION
Make it possible for a route instance to define the method to listen for (get, post, etc). Fallback to "all" if none is given.

Make it possible for a route to define a middleware to run before it gets handled. This allows for the middleware to call _next('route')_ and simply bypass the route handler. Good for redirecting purposes.

Better then this enhancements would be to work on issue #101 and then give the developer much more access to the express API itself, so we don't have to always create wrappers around express functionalities.
