### PR TITLE
Add theme scripts loading

### DIFF
--- a/applications/default/public/index.html
+++ b/applications/default/public/index.html
@@ -50,5 +50,7 @@
   <script src="js/controllers.js"></script>
   <script src="js/directives.js"></script>
   <script src="js/filters.js"></script>
+
+  <script ng-repeat="script in theme.scripts" ng-src="{{script}}"></script>
 </body>
 </html>


### PR DESCRIPTION
It seams to me that the feature for a theme to define JavaScript the way it can define CSS - in the theme settings file - is missing.

I'm not sure if this was on purpose, as in an Angular approaches you should consider having all of your JavaScript code attached to angular directives, and for that probably reside on choko extension directories, not themes, but it seems to make no harm to let the theme define JavaScript anyway.
