### PR TITLE
Remove versioning from Bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "choko",
-  "version": "1.0.0",
   "dependencies": {
     "bootstrap": "~3.1.0",
     "angular": "~1.2.13",


### PR DESCRIPTION
Although recommended, version number on Bower files is not mandatory. Sure it would be nice to have it there, but as we are using Bower only to manage front-end dependencies, I think it's easier and less confusing to keep choko version information only on package.json. For instance, right now the version in these files were diverging.
