### PR TITLE
Load environment specific settings files.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -137,6 +137,7 @@ Server.prototype.addApplication = function(hostname, dir, callback) {
 
     // Add default main settings file for this application.
     applicationSettings.push(applicationPaths[name] + '/settings.json');
+    applicationSettings.push(applicationPaths[name] + '/settings.local.json');
 
     // Loop through modes to register possible file paths.
     modes.forEach(function(mode) {
@@ -152,7 +153,7 @@ Server.prototype.addApplication = function(hostname, dir, callback) {
       if (fs.existsSync(filePath)) {
         mergingSettings.push(require(path.relative(__dirname, filePath)));
       }
-    })
+    });
   });
 
   // Load and merge all the settings.


### PR DESCRIPTION
This means to resolve #104 by creating a system to automatically load settings by environment for each application running with choko, including the core.

**P.s.: this adds a new dependency to choko; lodash.** [Lodash](http://lodash.com/) is a toolset full of ready-to-use functions to work with arry, objects, inheritance, and so on. I believe we would sometime need a dependency like that, anyway. In this case, I'm using it to deeply merge multiple objects into a new one (settings), and none of the already available libraries worked to solve this; neither has Prana's util tools. By the way, my recommendation is that at least in Choko, if not in Prana, we make the custom util be a wrapper of lodash, but with our own custom methods attached to it.
