### PR TITLE
Make lodash be extended by prana utils, not the other way arround.

### DIFF
--- a/lib/prana-patch.js
+++ b/lib/prana-patch.js
@@ -12,4 +12,5 @@ var lodash = require('lodash');
 prana.utils.mkdir = mkdirp;
 
 // Wrap lodash arround Prana utils.
-lodash.extend(prana.utils, lodash);
+lodash.extend(lodash, prana.utils);
+prana.utils = lodash;


### PR DESCRIPTION
I was having an issue probably related to the change on the way the method 'extend' works when expanding utils using lodash. By changing who extends who we solve this problem, and probably make more sense of it as Prana/Choko can have more specialized methods.
