### PR TITLE
Fixes application static override discovering method

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -390,7 +390,7 @@ Application.prototype.static = function(path) {
  * @return {String|Boolean} Path to the first file found or false.
  */
 Application.prototype.staticDiscover = function(filePath, callback) {
-  async.detect(this.statics, function(dir, next) {
+  async.detectSeries(this.statics, function(dir, next) {
     fs.exists(path.join(dir, filePath), next);
   },
   function(dir) {


### PR DESCRIPTION
The current ```Application.prototype.staticDiscover``` has a logic flaw when using ```async.detect``` method. This methods basically iterates an array asynchronously and uses the first value which it's iteration callback calls ```next``` with a ```true``` boolean. Although the order of execution of the iteration callback is correct, we are doing an IO operation which will not always respond in the correct order, even though the operation is basically the same in all iterations. That basically means that if the IO randomly decides to answer a second request before a first one we will lose the iteration order and therefore will mistake on the override order for extensions.

The solution is pretty simple: use ```async.detectSeries``` method, which will always wait for the execution of the ```next``` callback before moving forward to the next iteration.

*Note that this has a (probably minor) performance issue, that perhaps could be a bit diminished with the use of caching for static assets.*